### PR TITLE
build: make install create ~/.lv2 directory if needed

### DIFF
--- a/makefile
+++ b/makefile
@@ -31,6 +31,7 @@ folder:
 	
 
 install:
+	mkdir -p ~/.lv2
 	cp dsp/fabla.ttl fabla.lv2/
 	cp -r fabla.lv2 ~/.lv2/
 	cp -r presets/*.lv2 ~/.lv2/


### PR DESCRIPTION
The layout of ~/.lv2 is messed up if the directory did not exist before calling `make install`.

So create the directory upfront if necessary.
