### PR TITLE
Make MIDI note-off events trigger release

### DIFF
--- a/dsp/fabla.cxx
+++ b/dsp/fabla.cxx
@@ -415,6 +415,14 @@ static void noteOn(FABLA_DSP* self, int note, int velocity, int frame)
   //lv2_log_note(&self->logger, "noteOn done\n" );
 }
 
+static void noteOff(FABLA_DSP* self, int note, int frame)
+{
+  // release ADSR of note
+  for(int i = 0; i < NVOICES; i++)
+  {
+    self->voice[i]->stopIfNoteEquals( note );
+  }
+}
 
 static void
 activate(LV2_Handle instance)
@@ -510,13 +518,7 @@ run(LV2_Handle instance, uint32_t n_samples)
         
         int n = int(data[1]) - 36;
 
-        // release ADSR of note
-        for(int i = 0; i < NVOICES; i++)
-        {
-          self->voice[i]->stopIfNoteEquals( n );
-        }
-        
-        
+        noteOff( self, n, ev->time.frames );
       }
     } // MIDI event
     

--- a/dsp/fabla.cxx
+++ b/dsp/fabla.cxx
@@ -508,10 +508,12 @@ run(LV2_Handle instance, uint32_t n_samples)
         lv2_atom_forge_pop(&self->forge, &body_frame);
         lv2_atom_forge_pop(&self->forge, &set_frame);
         
+        int n = int(data[1]) - 36;
+
         // release ADSR of note
         for(int i = 0; i < NVOICES; i++)
         {
-          self->voice[i]->stopIfNoteEquals( int(data[1]) );
+          self->voice[i]->stopIfNoteEquals( n );
         }
         
         


### PR DESCRIPTION
Note that this does mean when 2 voices are playing the same note/sample, and a
note-off is received for that note, both voices will decay. This appears to be
what the original code intended, but wouldn't you really want only the oldest
voice to be released?
