### PR TITLE
Midi mapping indication and only responding to channel 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ launch Fabla as a standalone JACK client:
 $ ./run.sh
 ```
 
+Midi Mapping
+------
+Fabla responds to midi notes on channel **10**.
+The pads **1-16** map to midi notes **36-52**, anything outside that range 
+is clamped to the closest value, *midi note 0-36 triggers pad 1*, *midi note 52-127 triggers pad 16*.
+
 Contact
 -------
 If you have a particular question, email me!

--- a/dsp/fabla.cxx
+++ b/dsp/fabla.cxx
@@ -35,6 +35,8 @@
 
 #define NVOICES 64
 
+const uint8_t midi_channel = 0x09; //midi channel 10, standard for drums
+
 class SampleMessage
 {
   public:
@@ -471,7 +473,7 @@ run(LV2_Handle instance, uint32_t n_samples)
     if (ev->body.type == self->uris->midi_Event)
     {
       uint8_t* const data = (uint8_t* const)(ev + 1);
-      if ( (data[0] & 0xF0) == 0x90 ) // event & channel
+      if ( data[0] == (0x90 | midi_channel) ) // event & channel
       {
         //lv2_log_note(&self->logger, "Note on : %d, frame %i, event# this nframes %i\n", data[1], int(ev->time.frames), evCounter++ );
         lv2_atom_forge_frame_time(&self->forge, 0);
@@ -496,7 +498,7 @@ run(LV2_Handle instance, uint32_t n_samples)
         
         noteOn( self, n, v, ev->time.frames );
       }
-      else if ( (data[0] & 0xF0) == 0x80 )
+      else if ( data[0] == (0x80 | midi_channel) )
       {
         //lv2_log_note(&self->logger, "Note off: %d\n", data[1] );
         lv2_atom_forge_frame_time(&self->forge, 0);

--- a/dsp/fabla.cxx
+++ b/dsp/fabla.cxx
@@ -34,8 +34,7 @@
 #include "dsp_compressor.hxx"
 
 #define NVOICES 64
-
-const uint8_t midi_channel = 0x09; //midi channel 10, standard for drums
+#define MIDI_CHANNEL_DEFAULT 0x09 //shows up as '10', standard for drums
 
 class SampleMessage
 {
@@ -79,6 +78,8 @@ class PadData
 typedef struct {
   // instantiate values
   int sr;
+
+  uint8_t midi_channel;
   
   // port values
   float* master;
@@ -225,6 +226,7 @@ instantiate(const LV2_Descriptor*     descriptor,
   
   self->sr  = rate;
   self->bpm = 120.0f;
+  self->midi_channel = MIDI_CHANNEL_DEFAULT;
   
   self->schedule = 0;
   
@@ -473,7 +475,7 @@ run(LV2_Handle instance, uint32_t n_samples)
     if (ev->body.type == self->uris->midi_Event)
     {
       uint8_t* const data = (uint8_t* const)(ev + 1);
-      if ( data[0] == (0x90 | midi_channel) ) // event & channel
+      if ( data[0] == (0x90 | self->midi_channel) ) // event & channel
       {
         //lv2_log_note(&self->logger, "Note on : %d, frame %i, event# this nframes %i\n", data[1], int(ev->time.frames), evCounter++ );
         lv2_atom_forge_frame_time(&self->forge, 0);
@@ -498,7 +500,7 @@ run(LV2_Handle instance, uint32_t n_samples)
         
         noteOn( self, n, v, ev->time.frames );
       }
-      else if ( data[0] == (0x80 | midi_channel) )
+      else if ( data[0] == (0x80 | self->midi_channel) )
       {
         //lv2_log_note(&self->logger, "Note off: %d\n", data[1] );
         lv2_atom_forge_frame_time(&self->forge, 0);


### PR DESCRIPTION
Since the midi channel isn't configurable and considering the sample banks are drum focused, I figured it should respond to only the standard drum midi channel.
 I added a note in the README.md about the mappings.

addresses: https://github.com/openAVproductions/openAV-Fabla/issues/52