### PR TITLE
Fix for building with lv2 >= 1.18.0

### DIFF
--- a/gui/fabla_ui.cxx
+++ b/gui/fabla_ui.cxx
@@ -52,7 +52,7 @@ extern void initForge(Fabla*);
 extern void writeUpdateUiPaths(Fabla*);
 extern void writeLoadSample(Fabla* self, int pad, const char* filename, size_t filename_len);
 
-static LV2UI_Handle instantiate(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle instantiate(const struct LV2UI_Descriptor * descriptor,
                 const char * plugin_uri,
                 const char * bundle_path,
                 LV2UI_Write_Function write_function,


### PR DESCRIPTION
The update to lv2 1.18.0 dropped _LV2UI_Descriptor in favor of
LV2UI_Descriptor.