### PR TITLE
Respect CFLAGS, CXXFLAGS and LDFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,9 @@ set(FABLA_VERSION_MAJOR "1")
 set(FABLA_VERSION_MINOR "3")
 set(FABLA_VERSION_PATCH "2")
 
-set(FABLA_VERSION "${FABLA_VERSION_MAJOR}.${FABLA_VERSION_MINOR}.${FABLA_VERSION_PATCH}")
+option(BUILD_SSE "Build with SSE flags" ON)
 
-option(RELEASE_BUILD  "Build for production usage" ON )
+set(FABLA_VERSION "${FABLA_VERSION_MAJOR}.${FABLA_VERSION_MINOR}.${FABLA_VERSION_PATCH}")
 
 find_package(PkgConfig)
 
@@ -26,11 +26,15 @@ pkg_check_modules(SNDFILE sndfile REQUIRED)
 include_directories( ${SNDFILE_INCLUDE_DIRS}  )
 link_directories   ( ${SNDFILE_LIBRARY_DIRS}  )
 
-SET(CMAKE_SHARED_LINKER_FLAGS "-fPIC -shared -Wl,-z,nodelete -Wl,--no-undefined")
+SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fPIC -shared -Wl,-z,nodelete -Wl,--no-undefined")
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -O1 -Wno-unused-variable")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -O1 -Wno-unused-variable -ftree-vectorize")
 
-IF(RELEASE_BUILD)
-  SET(CMAKE_CXX_FLAGS "-g -Wall -Wno-unused-variable -msse2 -mfpmath=sse -ffast-math")
-  SET(CMAKE_C_FLAGS "-g -Wall -W -Wno-unused-variable -msse2 -mfpmath=sse -ffast-math -Wno-trigraphs")
+IF(BUILD_SSE)
+  IF(NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+    SET(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -msse2 -mfpmath=sse -ffast-math")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -mfpmath=sse -ffast-math -Wno-trigraphs")
+  ENDIF()
 ENDIF()
 
 # print config


### PR DESCRIPTION
CMakeLists.txt:
Respect externally set CFLAGS, CXXFLAGS and LDFLAGS.
Removing RELEASE_BUILD based custom CFLAGS/CXXFLAGS and adding BUILD_SSE
(similar to openav-artyfx).

Similar to https://github.com/openAVproductions/openAV-ArtyFX/issues/42 this fixes the issue, that external CFLAGS/CXXFLAGS/LDFLAGS are not respected.