### PR TITLE
Fix building with latest LV2

### DIFF
--- a/gui/fabla_ui.cxx
+++ b/gui/fabla_ui.cxx
@@ -52,7 +52,7 @@ extern void initForge(Fabla*);
 extern void writeUpdateUiPaths(Fabla*);
 extern void writeLoadSample(Fabla* self, int pad, const char* filename, size_t filename_len);
 
-static LV2UI_Handle instantiate(const struct _LV2UI_Descriptor * descriptor,
+static LV2UI_Handle instantiate(const struct LV2UI_Descriptor * descriptor,
                 const char * plugin_uri,
                 const char * bundle_path,
                 LV2UI_Write_Function write_function,


### PR DESCRIPTION
Latest LV2 removed the underscore prefix from many functions.
See https://github.com/lv2/lv2/commit/0080c435932349af4ed6e8ca8f4f09d5c3d71845