### PR TITLE
Fix FAILs in ttl

### DIFF
--- a/dsp/fabla.ttl
+++ b/dsp/fabla.ttl
@@ -12,10 +12,9 @@
 
 <http://www.openavproductions.com/fabla/gui>
   a ui:X11UI ;
-  lv2:requiredFeature urid:map ;
+  lv2:requiredFeature urid:map , ui:idleInterface ;
   lv2:optionalFeature ui:noUserResize ;
-  lv2:extensionData ui:showInterface,
-                    ui:idleInterface ;
+  lv2:extensionData ui:idleInterface ;
   
   ui:portNotification [
     ui:plugin <http://www.openavproductions.com/fabla> ;
@@ -29,6 +28,8 @@
   doap:name "Fabla" ;
   doap:description "Performance Sampler" ;
   doap:maintainer [ foaf:name "OpenAV Productions" ] ;
+  lv2:microVersion 2 ;
+	lv2:minorVersion 3 ;
   
   lv2:binary <fabla.so> ;
   lv2:requiredFeature urid:map;

--- a/dsp/fabla.ttl
+++ b/dsp/fabla.ttl
@@ -29,7 +29,7 @@
   doap:description "Performance Sampler" ;
   doap:maintainer [ foaf:name "OpenAV Productions" ] ;
   lv2:microVersion 2 ;
-	lv2:minorVersion 3 ;
+  lv2:minorVersion 3 ;
   
   lv2:binary <fabla.so> ;
   lv2:requiredFeature urid:map;


### PR DESCRIPTION
Welcome back at Github. I quickly fixed the FAILs mentioned in issue #59 . `idleInterface` is a `requiredFeature`. And `showInterface` shouldn't be in the extension data if you don't use it. `minorVersion` and `microVersion` are added with the numbers or your latest release 1.3.2 (odd minor version number!).

Optionally:  `-fvisibility=hidden` in CFLAGS and CXXFLAGS (to get rid of the globally visible symbols)